### PR TITLE
Fix maxlen maximum value

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -136,7 +136,7 @@ func (p *parser) consumeMaxLength() (int, error) {
 
 		maxlen *= 10
 		maxlen += int(c - '0')
-		if maxlen >= 1000 || len(p.r) == 0 {
+		if maxlen >= 9999 || len(p.r) == 0 {
 			break
 		}
 	}


### PR DESCRIPTION
`max-length` can be a 4 digits number according to the RFC:
 
> max-length    =  %x31-39 0*3DIGIT   ; positive integer < 10000

This PR fixes the implementation.