### PR TITLE
Use a non-capturing group for literals

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -25,7 +25,7 @@ func (l literals) expand(b *strings.Builder, _ Values) error {
 }
 
 func (l literals) regexp(b *strings.Builder) {
-	b.WriteByte('(')
+	b.WriteString("(?:")
 	b.WriteString(regexp.QuoteMeta(string(l)))
 	b.WriteByte(')')
 }


### PR DESCRIPTION
Saves some memory and improves performance a bit.