### PR TITLE
Use strings.Builder instead of bytes.Buffer

### DIFF
--- a/escape.go
+++ b/escape.go
@@ -7,7 +7,6 @@
 package uritemplate
 
 import (
-	"bytes"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -78,7 +77,7 @@ func (rc runeClass) String() string {
 	return strings.Join(ret, "+")
 }
 
-func pctEncode(w *bytes.Buffer, r rune) {
+func pctEncode(w *strings.Builder, r rune) {
 	if s := r >> 24 & 0xff; s > 0 {
 		w.Write([]byte{'%', hex[s/16], hex[s%16]})
 	}
@@ -137,14 +136,14 @@ func pctDecode(s string) string {
 	return string(buf)
 }
 
-type escapeFunc func(*bytes.Buffer, string) error
+type escapeFunc func(*strings.Builder, string) error
 
-func escapeLiteral(w *bytes.Buffer, v string) error {
+func escapeLiteral(w *strings.Builder, v string) error {
 	w.WriteString(v)
 	return nil
 }
 
-func escapeExceptU(w *bytes.Buffer, v string) error {
+func escapeExceptU(w *strings.Builder, v string) error {
 	for i := 0; i < len(v); {
 		r, size := utf8.DecodeRuneInString(v[i:])
 		if r == utf8.RuneError {
@@ -160,7 +159,7 @@ func escapeExceptU(w *bytes.Buffer, v string) error {
 	return nil
 }
 
-func escapeExceptUR(w *bytes.Buffer, v string) error {
+func escapeExceptUR(w *strings.Builder, v string) error {
 	for i := 0; i < len(v); {
 		r, size := utf8.DecodeRuneInString(v[i:])
 		if r == utf8.RuneError {

--- a/expression.go
+++ b/expression.go
@@ -7,24 +7,24 @@
 package uritemplate
 
 import (
-	"bytes"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 type template interface {
-	expand(*bytes.Buffer, Values) error
-	regexp(*bytes.Buffer)
+	expand(*strings.Builder, Values) error
+	regexp(*strings.Builder)
 }
 
 type literals string
 
-func (l literals) expand(w *bytes.Buffer, _ Values) error {
-	w.Write([]byte(l))
+func (l literals) expand(b *strings.Builder, _ Values) error {
+	b.WriteString(string(l))
 	return nil
 }
 
-func (l literals) regexp(b *bytes.Buffer) {
+func (l literals) regexp(b *strings.Builder) {
 	b.WriteByte('(')
 	b.WriteString(regexp.QuoteMeta(string(l)))
 	b.WriteByte(')')
@@ -95,7 +95,7 @@ func (e *expression) init() {
 	}
 }
 
-func (e *expression) expand(w *bytes.Buffer, values Values) error {
+func (e *expression) expand(w *strings.Builder, values Values) error {
 	first := true
 	for _, varspec := range e.vars {
 		value := values.Get(varspec.name)
@@ -118,7 +118,7 @@ func (e *expression) expand(w *bytes.Buffer, values Values) error {
 	return nil
 }
 
-func (e *expression) regexp(b *bytes.Buffer) {
+func (e *expression) regexp(b *strings.Builder) {
 	if e.first != "" {
 		b.WriteString("(?:") // $1
 		b.WriteString(regexp.QuoteMeta(e.first))
@@ -153,7 +153,7 @@ func (e *expression) regexp(b *bytes.Buffer) {
 	b.WriteByte('?')
 }
 
-func runeClassToRegexp(b *bytes.Buffer, class runeClass, named bool) {
+func runeClassToRegexp(b *strings.Builder, class runeClass, named bool) {
 	b.WriteString("(?:(?:[")
 	if class&runeClassR == 0 {
 		b.WriteString(`\x2c`)

--- a/uritemplate.go
+++ b/uritemplate.go
@@ -7,9 +7,9 @@
 package uritemplate
 
 import (
-	"bytes"
 	"log"
 	"regexp"
+	"strings"
 	"sync"
 )
 
@@ -88,7 +88,7 @@ func (t *Template) Varnames() []string {
 
 // Expand returns an URI reference corresponding t and vars.
 func (t *Template) Expand(vars Values) (string, error) {
-	w := bytes.Buffer{}
+	var w strings.Builder
 	for i := range t.exprs {
 		expr := t.exprs[i]
 		if err := expr.expand(&w, vars); err != nil {
@@ -106,7 +106,7 @@ func (t *Template) Regexp() *regexp.Regexp {
 		return t.re
 	}
 
-	b := bytes.Buffer{}
+	var b strings.Builder
 	b.WriteByte('^')
 	for i := range t.exprs {
 		expr := t.exprs[i]

--- a/value.go
+++ b/value.go
@@ -6,9 +6,7 @@
 
 package uritemplate
 
-import (
-	"bytes"
-)
+import "strings"
 
 type Values map[string]Value
 
@@ -84,7 +82,7 @@ func (v Value) Valid() bool {
 	}
 }
 
-func (v Value) expand(w *bytes.Buffer, spec varspec, exp *expression) error {
+func (v Value) expand(w *strings.Builder, spec varspec, exp *expression) error {
 	switch v.T {
 	case ValueTypeString:
 		val := v.V[0]


### PR DESCRIPTION
`strings.Builder` (introduced in Go 1.10) is a bit faster and minimizes memory copying.