### PR TITLE
Add benchmarks

### DIFF
--- a/uritemplate_test.go
+++ b/uritemplate_test.go
@@ -236,6 +236,42 @@ func BenchmarkExpressionExpand(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tmpl.Expand(testExpressionExpandVarMap)
+		if _, err := tmpl.Expand(testExpressionExpandVarMap); err != nil {
+			b.Errorf("got unexpected error; %#v", err)
+			return
+		}
+	}
+}
+
+func BenchmarkMatch(b *testing.B) {
+	tmpl := MustNew("https://{host}/users{/user}{/media}")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if nil == tmpl.Match("https://example.com/users/kevin/pics") {
+			b.Errorf("Must match")
+			return
+		}
+	}
+}
+
+func BenchmarkRegexpMatch(b *testing.B) {
+	tmpl := MustNew("https://{host}/users{/user}{/media}")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !tmpl.Regexp().MatchString("https://example.com/users/kevin/pics") {
+			b.Errorf("Must match")
+			return
+		}
+	}
+}
+
+func BenchmarkRegexpFindAll(b *testing.B) {
+	tmpl := MustNew("https://{host}/users{/user}{/media}")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if tmpl.Regexp().FindStringSubmatch("https://example.com/users/kevin/pics") == nil {
+			b.Errorf("Must match")
+			return
+		}
 	}
 }


### PR DESCRIPTION
This PR adds two new benchmarks for the Regex generators. Here are the results on my machine (Macbook 2,5 GHz Intel Core i7 4 core, 16 Go 1600 MHz DDR3, SSD):

```
Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^(BenchmarkMatch)$ -v -count=1

goos: darwin
goarch: amd64
BenchmarkMatch
BenchmarkMatch-8       20601         58640 ns/op       54272 B/op        660 allocs/op
PASS
ok      _/Users/dunglas/workspace/uritemplate   1.875s


Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^(BenchmarkRegexpMatch)$ -v -count=1

goos: darwin
goarch: amd64
BenchmarkRegexpMatch
BenchmarkRegexpMatch-8       1000000          1049 ns/op           0 B/op          0 allocs/op
PASS
ok      _/Users/dunglas/workspace/uritemplate   1.117s


Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^(BenchmarkRegexpFindAll)$ -v -count=1

goos: darwin
goarch: amd64
BenchmarkRegexpFindAll
BenchmarkRegexpFindAll-8      934981          1271 ns/op         192 B/op          2 allocs/op
PASS
ok      _/Users/dunglas/workspace/uritemplate   1.269s
```

According to these benchmarks, using regexp is always faster and consumes less memory than using the `tmpl.Match()` method. So I wonder if there is any benefits to keep the non-regexp based method?